### PR TITLE
Updated swiftformat

### DIFF
--- a/steps/format
+++ b/steps/format
@@ -8,7 +8,7 @@ RULES="
   --indent 4
   --ranges nospace
   --wraparguments beforefirst
-  --wrapelements beforefirst
+  --wrapcollections beforefirst
   --disable redundantReturn
   --disable spaceInsideBrackets
 "

--- a/steps/format
+++ b/steps/format
@@ -9,8 +9,7 @@ RULES="
   --ranges nospace
   --wraparguments beforefirst
   --wrapcollections beforefirst
-  --disable redundantReturn
-  --disable spaceInsideBrackets
+  --disable redundantParens,redundantReturn,spaceInsideBrackets
 "
 
 if ! [ -x "$(command -v swiftformat)" ]; then


### PR DESCRIPTION
`redundantParens` was causing failures for Schemata.